### PR TITLE
Bump versions so things work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,9 @@
-FROM ruby:latest
-
+# syntax=docker/dockerfile:1
+FROM ruby:3.0
+RUN apt-get update -qq && apt-get install -y nodejs npm postgresql-client
 EXPOSE 5000
 
 ENV RAILS_ENV=test
-
-# Add official postgresql apt deb source
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && apt-get update \
-    && apt-get install -y postgresql-client-10
-
-# Node, needed for asset pipeline
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
-    && apt-get update \
-    && apt-get install -y nodejs \
-    && npm install -q -g npm
 
 # Add the wait-for-it.sh script for waiting on dependent containers
 RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /usr/local/bin/wait-for-it.sh \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.15.1
+   2.2.22

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,10 +35,10 @@ services:
     entrypoint: wait-for-it.sh db:5432 -s -- wait-for-it.sh redis:6379 -s -- wait-for-it.sh memcache:11211 -s --
 
   db:
-    image: postgres
+    image: postgres:latest
 
   redis:
-    image: redis
+    image: redis:latest
 
   memcache:
-    image: tutum/memcached
+    image: memcached:latest


### PR DESCRIPTION
Old versions of things no longer worked, this moves to apt based packages for npm and nodejs, which seems to work. 